### PR TITLE
format multiple SSH keys output as multiline list

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -1089,7 +1089,10 @@ load_ssh_keys() {
 		[ -n "$timeout" ] && $confirmopt && blurb="${blurb},"
 		$confirmopt && blurb="${blurb}confirm"
 		[ -n "$blurb" ] && blurb=" (${blurb})"
-		mesg "ssh-add: Identities added: $sshkeys${blurb}"
+		mesg "ssh-add: Identities added:"
+		for key in "$@"; do
+			qprint "   - $key${blurb}"
+		done
 	else
 		warn "ssh-add failed: (return code: $ret; output: $sshout)"
 	fi


### PR DESCRIPTION
Updated `load_ssh_keys` function:  the output of the ssh-add to list added SSH keys individually for better clarity.

Before:
```
* ssh-add: Identities added: /home/USER/.ssh/key1
/home/USER/.ssh/key2
/home/USER/.ssh/key3
```

After:
```
* ssh-add: Identities added:
   - /home/USER/.ssh/key1
   - /home/USER/.ssh/key2
   - /home/USER/.ssh/key3
```