### PR TITLE
Expand IdentityFile paths from .ssh/config using tildes

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -688,6 +688,12 @@ all_host_identities() {
 		case $line in
 			*[Ii][Dd][Ee][Nn][Tt][Ii][Tt][Yy][Ff][Ii][Ll][Ee]*)
 				keyf="$(echo "$line" | awk '{print $2}')"
+				# shellcheck disable=SC2088 # preserve literal tilde
+				case "$keyf" in
+					"~/"*)  # Match unexpanded tilde
+						# Manually expand ~ -> $HOME
+						keyf="${HOME}/${keyf#"~/"}"
+				esac
 				if [ -f "$keyf" ]; then
 					echo "sshk:${keyf}"
 				else


### PR DESCRIPTION
If one uses ~ in `.ssh/config` for specifying IdentifyFile paths relative to the HOME directory keychain does not expand those as part of all_host_identities: tilde expansion precedes shell parameter expansion. As a result if one also uses the `--confallhosts` flag then those keys are not found as part of the `if [ -f "$keyf" ]; then` check and are marked as missing.

shellcheck's [SC2088](https://www.shellcheck.net/wiki/SC2088) _Tilde does not expand in quotes_ (disabled in the patch) describes the issue this addresses.