### PR TITLE
feat: enhance robustness of --confallhosts parsing

### DIFF
--- a/keychain.sh
+++ b/keychain.sh
@@ -684,15 +684,25 @@ all_host_identities() {
 	if [ ! -e ~/.ssh/config ]; then
 		warn "No ~/.ssh/config -- can't extract host identities" && return
 	fi
-	while IFS= read -r line; do
+	while IFS= read -r line || [ -n "$line" ]; do
+		# trim leading whitespace to simplify matching
+		line="$(echo "$line" | sed 's/^[[:space:]]*//')"
 		case $line in
-			*[Ii][Dd][Ee][Nn][Tt][Ii][Tt][Yy][Ff][Ii][Ll][Ee]*)
-				keyf="$(echo "$line" | awk '{print $2}')"
+			# skip commented lines
+			\#*)
+				continue
+				;;
+			[Ii][Dd][Ee][Nn][Tt][Ii][Tt][Yy][Ff][Ii][Ll][Ee]*)
+				# collect key path and strip potential surrounding double quotes
+				keyf="$(echo "$line" | awk '{print $2}' | sed -e 's/^"//' -e 's/"$//')"
+				# sub valid homedir prefixes (~, %d, ${HOME}) for absolute homedir
+				keyf="$(echo "$keyf" | sed "s:^\(~\|%d\|\${HOME}\):${HOME}:")"
 				if [ -f "$keyf" ]; then
 					echo "sshk:${keyf}"
 				else
 					echo "miss:${keyf}"
 				fi
+				;;
 		esac
 	done < ~/.ssh/config
 }


### PR DESCRIPTION
alternate to #197
closes #198

## changes

- enhance robustness of `--confallhosts` parsing
- it should now gracefully handle...
    - the very last config line if it doesn't end with a newline
        - `|| [ -n "$line"]` was new to me, I never realized that `read -r` would drop the final line if it didn't end with a newline
    - leading whitespace
    - commented lines
    - quoted arguments
    - known homedir shorthands

## validation

I churned on this locally by piping in this file, which includes examples for each resolved issue I believe

- leading space or tab that should be stripped
- leading tab
- commented lines that should be ignored, both with and without whitespace between `#` and the keyword
- unquoted and quoted examples of absolute path and all three homedir shorthands

```
#IdentityFile /home/user/.ssh/commented
 #IdentityFile /home/user/.ssh/commented
	#IdentityFile /home/user/.ssh/commented
# IdentityFile /home/user/.ssh/commented
 # IdentityFile /home/user/.ssh/commented
	# IdentityFile /home/user/.ssh/commented
IdentityFile /home/<REAL_USER_PLACEHOLDER>/.ssh/codeberg
IdentityFile "/home/<REAL_USER_PLACEHOLDER>/.ssh/codeberg"
IdentityFile ~/.ssh/codeberg
IdentityFile "~/.ssh/codeberg"
IdentityFile %d/.ssh/codeberg
IdentityFile "%d/.ssh/codeberg"
IdentityFile ${HOME}/.ssh/codeberg
IdentityFile "${HOME}/.ssh/codeberg"
```

## context

I ran into this again recently while setting up a new system and remembered that I'd encountered the lack of `~` parsing back when `--confallhosts` first shipped but I failed to actually report it :smiling_face_with_tear:.

found #198 and #197 when looking to see if anyone had tried to fix it yet, and reviewing the PR got me thinking about the problem space and all the various little ways `ssh_config` parsing is "fun", several of which I mention in my issue comment here: <https://github.com/danielrobbins/keychain/issues/198#issuecomment-3904854714>

after doing the reading and writing the explanation I felt silly and realized I should probably just open a PR that covers all the edge cases I'd brought up.

