### PR TITLE
Fix macOS GPG CI coverage

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -164,3 +164,66 @@ jobs:
           python -m pip install -e '.[dev]'
       - name: pytest
         run: python -m pytest -v --tb=short --cov=src/keychain --cov-branch --cov-report=term-missing:skip-covered
+
+  # -------------------------------------------------------------------------
+  # Synthetic aggregate check for branch/ruleset protection.
+  #
+  # GitHub branch rules can require this single stable check instead of every
+  # matrix expansion above. Keep this job last and include every CI job in
+  # ``needs`` so a green ``ci-passing`` means the relevant CI tier passed.
+  # -------------------------------------------------------------------------
+  ci-passing:
+    name: ci-passing
+    if: ${{ always() }}
+    needs:
+      - static-analysis
+      - test-fast
+      - test-rocky8-py39
+      - test-full-sweep
+    runs-on: ubuntu-latest
+    env:
+      STATIC_ANALYSIS_RESULT: ${{ needs.static-analysis.result }}
+      TEST_FAST_RESULT: ${{ needs.test-fast.result }}
+      TEST_ROCKY8_RESULT: ${{ needs.test-rocky8-py39.result }}
+      TEST_FULL_SWEEP_RESULT: ${{ needs.test-full-sweep.result }}
+      TEST_FULL_SWEEP_REQUIRED: >-
+        ${{
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+        }}
+    steps:
+      - name: Verify aggregate CI status
+        run: |
+          echo "static-analysis: ${STATIC_ANALYSIS_RESULT}"
+          echo "test-fast: ${TEST_FAST_RESULT}"
+          echo "test-rocky8-py39: ${TEST_ROCKY8_RESULT}"
+          echo "test-full-sweep: ${TEST_FULL_SWEEP_RESULT} (required: ${TEST_FULL_SWEEP_REQUIRED})"
+
+          failed=0
+
+          for result in \
+            "${STATIC_ANALYSIS_RESULT}" \
+            "${TEST_FAST_RESULT}" \
+            "${TEST_ROCKY8_RESULT}"
+          do
+            if [ "${result}" != "success" ]; then
+              failed=1
+            fi
+          done
+
+          if [ "${TEST_FULL_SWEEP_REQUIRED}" = "true" ]; then
+            if [ "${TEST_FULL_SWEEP_RESULT}" != "success" ]; then
+              failed=1
+            fi
+          elif [ "${TEST_FULL_SWEEP_RESULT}" != "success" ] && [ "${TEST_FULL_SWEEP_RESULT}" != "skipped" ]; then
+            failed=1
+          fi
+
+          if [ "${failed}" -ne 0 ]; then
+            echo "CI did not pass."
+            exit 1
+          fi
+
+          echo "CI passed."

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -50,15 +50,14 @@ jobs:
   # -------------------------------------------------------------------------
   # Fast tier — runs on every event (PR, push, cron, dispatch).
   #
-  # Floor + ceiling on Linux + Windows-on-ceiling. Rationale:
+  # Floor + ceiling on Linux + Windows/macOS-on-ceiling. Rationale:
   #   - 3.9 (floor) catches usage of features added later.
   #   - 3.13 (ceiling) catches deprecations and stdlib drift.
   #   - Windows × 3.13 catches POSIX-only assumptions; OS-portability
   #     bugs almost never differ between Python minor versions, so one
   #     Windows job is enough for PR-time feedback.
-  #   - macOS is intentionally omitted from this tier because it's a
-  #     POSIX system whose failures correlate ~100% with Linux. The
-  #     full sweep below restores macOS coverage on master.
+  #   - macOS × 3.13 catches Darwin-specific POSIX edges, especially
+  #     AF_UNIX socket path limits that Linux does not share.
   # -------------------------------------------------------------------------
   test-fast:
     runs-on: ${{ matrix.os }}
@@ -71,6 +70,8 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.13"
           - os: windows-latest
+            python-version: "3.13"
+          - os: macos-latest
             python-version: "3.13"
     steps:
       - uses: actions/checkout@v4

--- a/tests/test_gpg_e2e.py
+++ b/tests/test_gpg_e2e.py
@@ -7,6 +7,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -111,19 +112,22 @@ def _kill_keychain_ssh_agents(home: Path) -> None:
 
 
 @pytest.fixture
-def gpg_home(tmp_path: Path):
-    home = tmp_path / "home"
+def gpg_home():
+    # macOS has a short AF_UNIX socket path limit, and gpg-agent creates
+    # sockets under GNUPGHOME. Pytest's default macOS tmp_path can be too long.
+    root = Path(tempfile.mkdtemp(prefix="kc-gpg-", dir="/tmp" if sys.platform == "darwin" else None))
+    home = root / "home"
     gnupg = home / ".gnupg"
     home.mkdir()
     gnupg.mkdir(mode=0o700)
 
-    passfile = tmp_path / "passphrase"
+    passfile = root / "passphrase"
     passfile.write_text("secret-pass", encoding="utf-8")
-    pinentry_log = tmp_path / "pinentry.log"
+    pinentry_log = root / "pinentry.log"
     pinentry_log.write_text("", encoding="utf-8")
-    pinentry = tmp_path / "pinentry-test"
+    pinentry = root / "pinentry-test"
     _write_fake_pinentry(pinentry, passfile, pinentry_log)
-    gpg_wrapper = tmp_path / "gpg-wrapper"
+    gpg_wrapper = root / "gpg-wrapper"
     _write_gpg_wrapper(gpg_wrapper, passfile)
     (gnupg / "gpg-agent.conf").write_text(
         f"pinentry-program {pinentry}\n"
@@ -150,6 +154,7 @@ def gpg_home(tmp_path: Path):
 
     _run(["gpgconf", "--kill", "gpg-agent"], env, timeout=10)
     _kill_keychain_ssh_agents(home)
+    shutil.rmtree(root, ignore_errors=True)
 
 
 def test_gpge_warms_encryption_subkey_for_decryption(gpg_home) -> None:


### PR DESCRIPTION
## Summary

- use a short temporary root for the GPG E2E test so `gpg-agent` sockets do not exceed macOS AF_UNIX path limits
- add one macOS 3.13 job to the fast CI tier so Darwin-specific POSIX failures are caught on PRs instead of only after merge

## Investigation

`python-ci` runs #24 and #26 failed only on `master` push full-sweep jobs. The PR/feature-branch runs were green because macOS was excluded from the fast tier. The failing jobs were all `test-full-sweep (macos-latest, 3.9..3.13)`, which points to a macOS-specific pytest failure rather than the docs/parser changes themselves.

The new GPG E2E test creates a `GNUPGHOME`, and `gpg-agent` creates sockets under that directory. macOS has a short AF_UNIX socket path limit, while pytest's default temporary directory on GitHub-hosted macOS runners lives under a long `/private/var/folders/...` path. This patch gives the GPG E2E test a short temp root.

## Verification

- `PYTHONPATH=src python -m pytest tests/test_gpg_e2e.py -q`
- `PYTHONPATH=src python -m pytest tests -q`
- `python -m ruff check .`
- `python -m mypy`
- pushed branch CI: https://github.com/danielrobbins/keychain/actions/runs/27316990210

The pushed branch CI passed, including the new `test-fast (macos-latest, 3.13)` job.