### PR TITLE
Mark unzip example as console input

### DIFF
--- a/docs/python-rationale.md
+++ b/docs/python-rationale.md
@@ -60,7 +60,7 @@ no package-manager ceremony, and no entry-point shim.
 Any rewrite that lost that property would have lost something real.
 
 Keychain 3 preserves it by shipping as a Python zipapp: a single executable
-`.pyz` file built from the `keychain` package and runnable on systems with
+`.pyz` file built from the `keychain` source tree and runnable on systems with
 Python 3.9 or newer. The release artifact can be renamed to `keychain`, marked
 executable, and dropped in `PATH` much like the historical shell script.
 

--- a/docs/python-rationale.md
+++ b/docs/python-rationale.md
@@ -82,7 +82,7 @@ well-aligned with what a credential helper should be.
 zip file with a shebang. For example:
 
 ```console
-unzip -p /usr/local/bin/keychain keychain/main.py
+$ unzip -p /usr/local/bin/keychain keychain/main.py
 ```
 
 That shows the source for the program installed on the machine. A native


### PR DESCRIPTION
## Summary

- Mark the unzip example as shell input with a `$` prompt.
- Keeps the Markdown readable on GitHub while allowing Kernel Seeds console rendering to style it as an input command.

## Validation

- Checked the rendered diff on GitHub.
- This is a documentation-only change.